### PR TITLE
Shifter additions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN useradd -u $VC3USERID vc3user
 RUN apt-get update && \
     apt-get install -y vim-tiny && \
     pip install --upgrade pip && \
-    pip install htcondor retrying
+    pip install htcondor==8.9.1 retrying
 
 COPY CHANGES.rst README.rst setup.py /code/
 COPY reana_job_controller/version.py /code/reana_job_controller/

--- a/files/job_wrapper.sh
+++ b/files/job_wrapper.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/bin/bash
 
 # Replicate input files directory structure
 # @TODO: This could be executed 
@@ -6,14 +6,18 @@
 
 # Expected arguments from htcondor_job_manager:
 # $1: workflow_workspace
-# $2: docker_img
-# $3: cmd (to run within container for reana workflow step)
+# $2: DOCKER_IMG
+# $3 -> : cmd 
+
+# Defining inputs
+DOCKER_IMG=$2
+REANA_WORKFLOW_DIR=$1
 
 # Get static version of parrot.
 # Note: We depend on curl for this.
 # Assumed to be available on HPC worker nodes (might need to transfer a static version otherwise).
 get_parrot(){
-    curl --retry 5 -o parrot_static_run http://download.virtualclusters.org/builder-files/parrot_static_run_v7.0.11
+    curl --retry 5 -o parrot_static_run http://download.virtualclusters.org/builder-files/parrot_static_run_v7.0.11 > /dev/null 2>&1 
     if [ -e "parrot_static_run" ]; then
         chmod +x parrot_static_run
     else
@@ -24,9 +28,10 @@ get_parrot(){
 
 populate(){
     if [ ! -x "$_CONDOR_SCRATCH_DIR/parrot_static_run" ]; then get_parrot; fi
-    mkdir -p "$_CONDOR_SCRATCH_DIR/$reana_workflow_dir"
-    local parent="$(dirname $reana_workflow_dir)"
-    $_CONDOR_SCRATCH_DIR/parrot_static_run -T 30 cp --no-clobber -r "/chirp/CONDOR/$reana_workflow_dir" "$_CONDOR_SCRATCH_DIR/$parent"
+    mkdir -p "$_CONDOR_SCRATCH_DIR/$REANA_WORKFLOW_DIR"
+    local parent="$(dirname $REANA_WORKFLOW_DIR)"
+    sleep 5000
+    $_CONDOR_SCRATCH_DIR/parrot_static_run -T 30 cp --no-clobber -r "/chirp/CONDOR/$REANA_WORKFLOW_DIR" "$_CONDOR_SCRATCH_DIR/$parent"
 }
 
 find_module(){
@@ -53,7 +58,7 @@ find_container(){
     local module_found=$?
 
     for cntr in "${search_list[@]}"; do
-        cntr_path="$(which $cntr 2>/dev/null)"
+        cntr_path="$(command -v $cntr)"
         if [[ -x "$cntr_path" ]] # Checking binaries in path
         then
             if [ "$(basename "$cntr_path")" == "$default" ]; then 
@@ -67,7 +72,7 @@ find_container(){
         if [ $module_found == 0 ]; then
             for var in ${module_list[*]}; do
                 module load $var 2>/dev/null
-                var_path="$(which $var 2>/dev/null)"
+                var_path="$(command -v $var 2>/dev/null)"
                 if [ "$(basename "$var_path")" == "$default" ]; then
                     container_path="$var_path"
                     return 0
@@ -89,33 +94,26 @@ find_container(){
 
 # Setting up cmd line args for singularity
 # Print's stdout the argument line for running singularity utilizing
-# the passed in variables
-# $1: workflow_workspace
-# $2: docker_img
-# $3: cmd (to run within container for reana workflow step)
 setup_singularity(){
-    echo "exec --home .$1:$1 docker://$2 $3"
+    echo "exec --home .$REANA_WORKFLOW_DIR:$REANA_WORKFLOW_DIR docker://$DOCKER_IMG"
 }
 
-# Setting up shifter. Pull the img first if not present, then
-# setup the 
+# Setting up shifter. Pull the docker_img into the shifter image gateway
+# and dump required arguments into stdout to be collected by a function call
 setup_shifter(){
     # Check for shifterimg
-    if [[ ! $(which shifterimg 2>/dev/null) ]]; then
+    if [[ ! $(command -v shifterimg 2>/dev/null) ]]; then
         echo "Error: shifterimg not found..." >&2
         exit 127
     fi
-    # Check if dockerimg is arleady on resource
-    if [[ ! shifterimg lookup "$2" >/dev/null 2>&1 ]]; then
-        # Pull if not available
-        if [[ ! shifterimg pull "$2" >/dev/null 2>&1 ]]; then
-            echo "Error: Could not pull img: $2" >&2 
-            exit 127
-        fi
+
+    # Attempt to pull image into image-gateway
+    if ! shifterimg pull "$DOCKER_IMG" >/dev/null 2>&1; then
+        echo "Error: Could not pull img: $DOCKER_IMG" >&2 
+        exit 127
     fi
     # Put arguments into stdout to collect
-    echo "--image=docker:$2 -- $3"
-
+    echo "--image=docker:$DOCKER_IMG --workdir=$REANA_WORKFLOW_DIR --"
 }
 
 # Setting up the arguments to pass to a container technology.
@@ -128,9 +126,9 @@ setup_container(){
     local container=$(basename "$container_path")
 
     if [ "$container" == "singularity" ]; then
-        arguments=$(setup_singularity)
+        cntr_arguments=$(setup_singularity)
     elif [ "$container" == "shifter" ]; then
-        arguments=$(setup_shifter)
+        cntr_arguments=$(setup_shifter)
     else
         echo "Error: Unrecognized container: $(basename $container_path)" >&2
         exit 127
@@ -155,18 +153,17 @@ if [ $? != 0 ]; then
     exit 127
 fi
 setup_container
-populate
+#populate
 
 ######## Execution ##########
-# exec "$singularity_path" "$@"
 # Note: Double quoted arguments are broken
 # and passed as multiple arguments
 # in bash for some reason, working that
 # around by dumping command to a
-# temporary wrapper file.
+# temporary wrapper file named tmpjob.
 tmpjob=$(mktemp -p .)
 chmod +x $tmpjob 
-echo "$container_path" "$arguments" > $tmpjob
+echo "$container_path" "$cntr_arguments" ${@:3} > $tmpjob
 bash $tmpjob
 res=$?
 rm $tmpjob
@@ -181,7 +178,7 @@ fi
 # via +PostCmd, eventually.
 # Not implemented yet.
 # Read files from $reana_workflow_outputs
-# and write them into $reana_workflow_dir
+# and write them into $REANA_WORKFLOW_DIR
 # Stage out depending on the protocol
 # E.g.:
 # - file: will be transferred via condor_chirp
@@ -190,13 +187,13 @@ fi
 # Use vc3-builder to get a static version
 # of parrot (eventually, a static version
 # of the chirp client only).
-if [ "x$reana_workflow_dir" == "x" ]; then
+if [ "x$REANA_WORKFLOW_DIR" == "x" ]; then
     echo "[Info]: Nothing to stage out"
     exit $res
 fi
 
-parent="$(dirname $reana_workflow_dir)"
+parent="$(dirname $REANA_WORKFLOW_DIR)"
 # TODO: Check for parrot exit code and propagate it in case of errors.
-./parrot_static_run -T 30 cp --no-clobber -r "$_CONDOR_SCRATCH_DIR/$reana_workflow_dir" "/chirp/CONDOR/$parent"
+#./parrot_static_run -T 30 cp --no-clobber -r "$_CONDOR_SCRATCH_DIR/$REANA_WORKFLOW_DIR" "/chirp/CONDOR/$parent"
 
 exit $res

--- a/files/job_wrapper.sh
+++ b/files/job_wrapper.sh
@@ -130,10 +130,8 @@ setup_shifter(){
         echo "Error: Could not pull img: $DOCKER_IMG" >&2 
         exit 127
     fi
-    # remove a "/" for shifter being too specific
-    local reana_mount=$(echo $REANA_WORKFLOW_DIR | cut -c 2-)
 
-    # Put arguments into stdout to collect. There is already a "/" in $RWD
+    # Put arguments into stdout to collect.
     echo "--image=docker:${DOCKER_IMG} --volume=$(pwd -P)/reana:/reana -- "
 }
 
@@ -180,7 +178,6 @@ chmod +x $tmpjob
 echo "$CONTAINER_ENV" "$CONTAINER_PATH" "$CNTR_ARGUMENTS" "${@:3} " > $tmpjob
 bash $tmpjob
 res=$?
-cp $tmpjob /u/sciteam/kankel1/
 rm $tmpjob
 
 if [ $res != 0 ]; then

--- a/files/job_wrapper.sh
+++ b/files/job_wrapper.sh
@@ -30,7 +30,6 @@ populate(){
     if [ ! -x "$_CONDOR_SCRATCH_DIR/parrot_static_run" ]; then get_parrot; fi
     mkdir -p "$_CONDOR_SCRATCH_DIR/$REANA_WORKFLOW_DIR"
     local parent="$(dirname $REANA_WORKFLOW_DIR)"
-    sleep 5000
     $_CONDOR_SCRATCH_DIR/parrot_static_run -T 30 cp --no-clobber -r "/chirp/CONDOR/$REANA_WORKFLOW_DIR" "$_CONDOR_SCRATCH_DIR/$parent"
 }
 
@@ -153,7 +152,7 @@ if [ $? != 0 ]; then
     exit 127
 fi
 setup_container
-#populate
+populate
 
 ######## Execution ##########
 # Note: Double quoted arguments are broken
@@ -194,6 +193,6 @@ fi
 
 parent="$(dirname $REANA_WORKFLOW_DIR)"
 # TODO: Check for parrot exit code and propagate it in case of errors.
-#./parrot_static_run -T 30 cp --no-clobber -r "$_CONDOR_SCRATCH_DIR/$REANA_WORKFLOW_DIR" "/chirp/CONDOR/$parent"
+./parrot_static_run -T 30 cp --no-clobber -r "$_CONDOR_SCRATCH_DIR/$REANA_WORKFLOW_DIR" "/chirp/CONDOR/$parent"
 
 exit $res

--- a/files/job_wrapper.sh
+++ b/files/job_wrapper.sh
@@ -52,7 +52,7 @@ find_container(){
     declare -a search_list=("singularity" "shifter")
     declare -a module_list=("singularity" "tacc-singularity" "shifter")
     declare -a found_list=()
-    local default="singularity"
+    local default="shifter"
     find_module
     local module_found=$?
 
@@ -94,7 +94,7 @@ find_container(){
 # Setting up cmd line args for singularity
 # Print's stdout the argument line for running singularity utilizing
 setup_singularity(){
-    echo "exec --home .$REANA_WORKFLOW_DIR:$REANA_WORKFLOW_DIR docker://$DOCKER_IMG"
+    echo "exec -B $REANA_WORKFLOW_DIR:/reana docker://$DOCKER_IMG"
 }
 
 # Setting up shifter. Pull the docker_img into the shifter image gateway
@@ -112,7 +112,7 @@ setup_shifter(){
         exit 127
     fi
     # Put arguments into stdout to collect
-    echo "--image=docker:$DOCKER_IMG --workdir=$REANA_WORKFLOW_DIR --"
+    echo "--image=docker:$DOCKER_IMG --volume=$REANA_WORKFLOW_DIR:/reana -- "
 }
 
 # Setting up the arguments to pass to a container technology.
@@ -162,7 +162,7 @@ populate
 # temporary wrapper file named tmpjob.
 tmpjob=$(mktemp -p .)
 chmod +x $tmpjob 
-echo "$container_path" "$cntr_arguments" ${@:3} > $tmpjob
+echo "$container_path" "$cntr_arguments" "bash -c \"cd /reana; ${@:3}\"" > $tmpjob
 bash $tmpjob
 res=$?
 rm $tmpjob

--- a/files/job_wrapper.sh
+++ b/files/job_wrapper.sh
@@ -30,7 +30,7 @@ populate(){
     if [ ! -x "$_CONDOR_SCRATCH_DIR/parrot_static_run" ]; then get_parrot; fi
     mkdir -p "$_CONDOR_SCRATCH_DIR/$REANA_WORKFLOW_DIR"
     local parent="$(dirname $REANA_WORKFLOW_DIR)"
-    #$_CONDOR_SCRATCH_DIR/parrot_static_run -T 30 cp --no-clobber -r "/chirp/CONDOR/$REANA_WORKFLOW_DIR" "$_CONDOR_SCRATCH_DIR/$parent"
+    $_CONDOR_SCRATCH_DIR/parrot_static_run -T 30 cp --no-clobber -r "/chirp/CONDOR/$REANA_WORKFLOW_DIR" "$_CONDOR_SCRATCH_DIR/$parent"
 }
 
 find_module(){
@@ -53,7 +53,7 @@ find_container(){
     declare -a found_list=()
     local default="singularity"
     local cont_found=false
-    local module_found=$?
+    
 
     for cntr in "${search_list[@]}"; do
         cntr_path="$(command -v $cntr)"
@@ -72,6 +72,7 @@ find_container(){
     if [ ! "$cont_found" ]; then
         for cntr in "${search_list[@]}"; do
             find_module
+            module_found=$?
             if [ $module_found == 0 ]; then
                 for var in ${search_list[*]}; do
                     module load $var 2>/dev/null
@@ -125,9 +126,6 @@ setup_shifter(){
         echo "Error: Could not pull img: $DOCKER_IMG" >&2 
         exit 127
     fi
-    # Move directories to avoid https://github.com/NERSC/shifter/issues/250
-    #mv "$REANA_WORKFLOW_DIR" "$HOME"/reana
-
 
     # Put arguments into stdout to collect
     echo "--image=docker:${DOCKER_IMG} --volume=${REANA_WORKFLOW_DIR}:/reana -- "

--- a/reana_job_controller/htcondor_job_manager.py
+++ b/reana_job_controller/htcondor_job_manager.py
@@ -151,8 +151,10 @@ class HTCondorJobManager(JobManager):
         sub = htcondor.Submit()
         sub['executable'] = self.wrapper
         # condor arguments require double quotes to be escaped
-        sub['arguments'] = 'exec --home .{0}:{0} docker://{1} {2}'.format(self.workflow_workspace,
-                self.docker_img, re.sub(r'"', '\\"', self.cmd))
+        #sub['arguments'] = 'exec --home .{0}:{0} docker://{1} {2}'.format(self.workflow_workspace,
+        #        self.docker_img, re.sub(r'"', '\\"', self.cmd))
+        sub['arguments'] = "{0} {1} {2}".format(self.workflow_workspace,self.docker_img,
+                re.sub(r'"', '\\"', self.cmd))
         sub['Output'] = '/tmp/$(Cluster)-$(Process).out'
         sub['Error'] = '/tmp/$(Cluster)-$(Process).err'
         #sub['transfer_input_files'] = get_input_files(self.workflow_workspace)


### PR DESCRIPTION
# Basic Shifter Execution Support
Changing `files/job_wrapper.sh` to abstract which container we are using for the RJC execution backend. Rather than relying on Singularity being present at all HPC sites Shifter support is added.

## Container Execution
Each container has different execution steps / arguments. Those are handled and passed through the functions `setup_singularity` and `setup_shifter`. To allow these changes in execution, `Singularity` support is no longer hard coded into `reana_job_controller/htcondor_job_manager.py`, and instead of passing raw `Singularity` specific commands only the necessary components are passed as arguments to `files/job_wrapper.sh`. See below:
```
sub['arguments'] = "{0} {1} {2}".format(self.workflow_workspace,self.docker_img, re.sub(r'"', '\\"', self.cmd))
```

## Shifter Issues
As volume mounting / binding in `Shifter` doesn't allow symlinks nor binding to protected directories (`/var` mainly here for `REANA`), the workflow directory mounting will need to be reworked from `/var/reana/. . .` to `/reana/. . .`. More testing is needed for this portion through `bosco`  and other remote submission methods.